### PR TITLE
add a build script

### DIFF
--- a/build-assistant.sh
+++ b/build-assistant.sh
@@ -1,0 +1,28 @@
+#! usr/bin/bash
+
+#echo $#
+
+if [[ $# -eq 0 ]]
+then
+  echo $'Usage: build-assistant.sh [OPTION]... \n OPTION can be: \n --compile-only    compile only the typescript \n --build    to perform a full build of the plugin \n --build-server    to build only the server-side, but pack everything (including the last build of the UI) into the jar';
+  exit 1;
+fi
+
+if [[ $1 == "--compile-only" ]]
+then
+  tsc --noImplicitAny --strictNullChecks --jsx react -p ./src/main/resources/theme/groups/account/src
+  exit 0;
+fi
+
+if [[ $1 == "--build" ]]
+then
+  mvn clean package -DskipTests -Dmaven.source.skip
+  exit 0;
+fi
+
+if [[ $1 == "--build-server" ]]
+then
+  mvn clean package -DskipTests -Dmaven.source.skip -DskipAccount2
+  exit 0;
+fi
+


### PR DESCRIPTION
This can be used to build the plugin easilly.

- **build-assistant.sh --compile-only**   --> will just compile the typescript (it takes less a couple of ms to check)
- **build-assistant.sh --build**     --> will perform a full build (UI and java) and produce the package under ./target folder
- **build-assistant.sh --build-server**     --> will perform a build (java classes only) and produce the full package (with the UI part from any previous full run) under ./target folder